### PR TITLE
Fixes potential NPE in WeakReference for Bitmap.

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/LineChartRenderer.java
@@ -82,7 +82,10 @@ public class LineChartRenderer extends LineRadarRenderer {
 
             if (width > 0 && height > 0) {
 
-                mDrawBitmap = new WeakReference<Bitmap>(Bitmap.createBitmap(width, height, mBitmapConfig));
+                mDrawBitmap = new WeakReference<>(Bitmap.createBitmap(width, height, mBitmapConfig));
+                if (mDrawBitmap.get() == null) {
+                    return;
+                }
                 mBitmapCanvas = new Canvas(mDrawBitmap.get());
             } else
                 return;


### PR DESCRIPTION
Bitmap.createBitmap could return a null Bitmap in certain cases.