### PR TITLE
Fixes avoidFirstLastClipping for last values.

### DIFF
--- a/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
+++ b/MPChartLib/src/main/java/com/github/mikephil/charting/renderer/XAxisRenderer.java
@@ -205,20 +205,18 @@ public class XAxisRenderer extends AxisRenderer {
                 String label = mXAxis.getValueFormatter().getFormattedValue(mXAxis.mEntries[i / 2], mXAxis);
 
                 if (mXAxis.isAvoidFirstLastClippingEnabled()) {
+                    // avoid clipping of the first
+                    if (i == 0) {
+                        float width = Utils.calcTextWidth(mAxisLabelPaint, label);
+                        x += width / 2;
 
                     // avoid clipping of the last
-                    if (i == mXAxis.mEntryCount - 1 && mXAxis.mEntryCount > 1) {
+                    } else if (i / 2 == mXAxis.mEntryCount - 1 && mXAxis.mEntryCount > 1) {
                         float width = Utils.calcTextWidth(mAxisLabelPaint, label);
 
                         if (width > mViewPortHandler.offsetRight() * 2
                                 && x + width > mViewPortHandler.getChartWidth())
                             x -= width / 2;
-
-                        // avoid clipping of the first
-                    } else if (i == 0) {
-
-                        float width = Utils.calcTextWidth(mAxisLabelPaint, label);
-                        x += width / 2;
                     }
                 }
 


### PR DESCRIPTION
The last value was clipped even when you had `setAvoidFirstLastClippingEnabled` set to `true`. This fixes that.