### PR TITLE
SMP-8657 Allow lint errors in MPChartLib

### DIFF
--- a/MPChartLib/build.gradle
+++ b/MPChartLib/build.gradle
@@ -18,6 +18,9 @@ android {
     testOptions {
         unitTests.returnDefaultValues = true // this prevents "not mocked" error
     }
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## PR Checklist:
- [x] I have tested this extensively and it does not break any existing behavior.
- [ ] ~~I have added/updated examples and tests for any new behavior.~~
- [ ] ~~If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]~~

## PR Description
Tiny preparation for ticket [SMP-8657](https://scalablecapital.atlassian.net/browse/SMP-8657) This PR is only about preventing `./gradlew lint` from failing due to errors in MPChartLib.
