### PR TITLE
SMP-12606 compileSdk and build.gradle update

### DIFF
--- a/MPChartExample/build.gradle
+++ b/MPChartExample/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdk 28
     defaultConfig {
         applicationId "com.xxmassdeveloper.mpchartexample"
         minSdkVersion 16

--- a/MPChartLib/build.gradle
+++ b/MPChartLib/build.gradle
@@ -3,11 +3,10 @@ apply plugin: 'com.android.library'
 group='com.github.philjay'
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion '30.0.2'
+    compileSdk 33
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 30
+        targetSdkVersion 33
     }
     buildTypes {
         release {
@@ -21,6 +20,7 @@ android {
     lintOptions {
         abortOnError false
     }
+    namespace 'com.github.mikephil.charting'
 }
 
 dependencies {
@@ -28,20 +28,21 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 }
 
-task sourcesJar(type: Jar) {
+tasks.register('sourcesJar', Jar) {
     from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
+    archiveClassifier = 'sources'
 }
 
-task javadoc(type: Javadoc) {
+tasks.register('javadoc', Javadoc) {
     options.charSet = 'UTF-8'
-    failOnError  false
+    failOnError false
     source = android.sourceSets.main.java.sourceFiles
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
 }
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+tasks.register('javadocJar', Jar) {
+    dependsOn javadoc
+    archiveClassifier = 'javadoc'
     from javadoc.destinationDir
 }
 

--- a/MPChartLib/src/main/AndroidManifest.xml
+++ b/MPChartLib/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.github.mikephil.charting">
+<manifest>
 
  <!--  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 


### PR DESCRIPTION
Part of 
### JIRA ticket : [SMP-12606](https://scalablecapital.atlassian.net/browse/SMP-12606)

### Checklist
- [X] I have tested the fix to verify that all acceptance criteria are met
- [X] I have used correct base and target branches
- [ ] Unit tests added or provided reasoning for not adding them
- [ ] QA Approved

## Objective
Upgrade gradle to 8.1.2
Higher version not reachable with the latest stable AS (Giraffe)
<img width="682" alt="Screenshot 2023-11-07 at 12 54 30" src="https://github.com/ScaCap/sc-android/assets/12126043/6209cba7-9e8b-4a95-ab11-7147a1f4406e">

<img width="878" alt="Screenshot 2023-11-07 at 13 27 54" src="https://github.com/ScaCap/sc-android/assets/12126043/4ac89b3a-cfe9-4c45-be38-6ae10980637b">

https://developer.android.com/build/releases/gradle-plugin

## Proposed solution
Changed the version, which produced a number of build errors like 

`Caused by: org.gradle.api.GradleException: 'compileJava' task (current target is 17) and 'compileKotlin' task...`

`'compileDebugJavaWithJavac' task (current target is 1.8) and 'kaptGenerateStubsDebugKotlin' task...`

So I also force updated all java versions to 17

## Potential Caveats
Shouldn't be any if you're using jdk 17 :thinking: 




[SMP-12606]: https://scalablecapital.atlassian.net/browse/SMP-12606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ